### PR TITLE
Update IcoTools to .NET 6

### DIFF
--- a/src/IcoCat/IcoCat.csproj
+++ b/src/IcoCat/IcoCat.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
     <RootNamespace>Ico.Cat</RootNamespace>
     <LangVersion>latest</LangVersion>
     <Version>1.1.0</Version>

--- a/src/IcoCrush/IcoCrush.cs
+++ b/src/IcoCrush/IcoCrush.cs
@@ -31,7 +31,7 @@ namespace Ico
             {
                 PngEncoder = new SixLabors.ImageSharp.Formats.Png.PngEncoder
                 {
-                    CompressionLevel = 9,
+                    CompressionLevel = SixLabors.ImageSharp.Formats.Png.PngCompressionLevel.Level9,
                     ColorType = SixLabors.ImageSharp.Formats.Png.PngColorType.RgbWithAlpha,
                 },
 

--- a/src/IcoCrush/IcoCrush.csproj
+++ b/src/IcoCrush/IcoCrush.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
     <LangVersion>7.2</LangVersion>
     <RootNamespace>Ico.Crush</RootNamespace>
     <Version>1.1.0</Version>
@@ -17,7 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.3.0" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.0-beta0005" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/IcoCut/IcoCut.csproj
+++ b/src/IcoCut/IcoCut.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
     <RootNamespace>Ico.Cut</RootNamespace>
     <LangVersion>latest</LangVersion>
     <Version>1.1.0</Version>

--- a/src/IcoExtract/IcoExtract.cs
+++ b/src/IcoExtract/IcoExtract.cs
@@ -43,7 +43,7 @@ namespace Ico.Extract
                     Reporter = Reporter,
                     PngEncoder = new SixLabors.ImageSharp.Formats.Png.PngEncoder
                     {
-                        CompressionLevel = 9,
+                        CompressionLevel = SixLabors.ImageSharp.Formats.Png.PngCompressionLevel.Level9,
                         ColorType = SixLabors.ImageSharp.Formats.Png.PngColorType.RgbWithAlpha,
                     },
                 };

--- a/src/IcoExtract/IcoExtract.csproj
+++ b/src/IcoExtract/IcoExtract.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
     <RootNamespace>Ico.Extract</RootNamespace>
     <LangVersion>latest</LangVersion>
     <Version>1.1.0</Version>

--- a/src/IcoInfo/IcoInfo.csproj
+++ b/src/IcoInfo/IcoInfo.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
     <LangVersion>latest</LangVersion>
     <RootNamespace>Ico.Info</RootNamespace>
     <Version>1.1.0</Version>

--- a/src/IcoLib/Codecs/BmpDecoder.cs
+++ b/src/IcoLib/Codecs/BmpDecoder.cs
@@ -124,7 +124,7 @@ namespace Ico.Codecs
                 }
 
                 c.A = 255;
-                colorTable[i] = c.ToRgba32();
+                c.ToRgba32(ref colorTable[i]);
             }
 
             var padding = reader.SeekOffset % 4;
@@ -140,7 +140,7 @@ namespace Ico.Codecs
                     if (colorIndex >= colorTableSize)
                     {
                         anyIndexOutOfBounds = true;
-                        source.CookedData[x, y] = Rgba32.Black;
+                        source.CookedData[x, y] = Color.Black;
                     }
                     else
                     {
@@ -234,7 +234,9 @@ namespace Ico.Codecs
                 for (var x = 0; x < width; x++)
                 {
                     var colorValue = new Bgra32 { PackedValue = reader.NextUint32() };
-                    source.CookedData[x, y] = colorValue.ToRgba32();
+                    Rgba32 rgba32Value = source.CookedData[x, y]; // the ref keyword cannot be used on this indexer, so we need a temporary
+                    colorValue.ToRgba32(ref rgba32Value);
+                    source.CookedData[x, y] = rgba32Value;
                 }
             }
 

--- a/src/IcoLib/Codecs/PngDecoder.cs
+++ b/src/IcoLib/Codecs/PngDecoder.cs
@@ -5,6 +5,7 @@ using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
 using System;
 using System.IO;
+using System.Threading;
 
 namespace Ico.Codecs
 {
@@ -27,7 +28,7 @@ namespace Ico.Codecs
             using (var stream = new MemoryStream(bitmapHeader.Data.ToArray()))
             {
                 var decoder = new SixLabors.ImageSharp.Formats.Png.PngDecoder();
-                source.CookedData = decoder.Decode<Rgba32>(new Configuration(), stream);
+                source.CookedData = decoder.Decode<Rgba32>(new Configuration(), stream, CancellationToken.None);
             }
 
             source.Encoding.Type = IcoEncodingType.Png;
@@ -77,7 +78,7 @@ namespace Ico.Codecs
 
         public static PngFileEncoding GetPngFileEncoding(Memory<byte> data)
         {
-            var reader = new ByteReader(data, ByteOrder.NetworkEndian);
+            var reader = new ByteReader(data, Ico.Binary.ByteOrder.NetworkEndian);
             if (FileFormatConstants._pngHeader != reader.NextUint64())
             {
                 throw new InvalidPngFileException(IcoErrorCode.NotPng, $"Data stream does not begin with the PNG magic constant");

--- a/src/IcoLib/IcoLib.csproj
+++ b/src/IcoLib/IcoLib.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.0-beta0005" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.1" />
   </ItemGroup>
 
 </Project>

--- a/src/IcoNag/IcoNag.csproj
+++ b/src/IcoNag/IcoNag.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
     <RootNamespace>Ico.Nag</RootNamespace>
     <Version>1.1.0</Version>
     <Authors>Jeffrey Tippet</Authors>


### PR DESCRIPTION
This required one major change and a couple resultant minor changes.

1. ImageSharp 2+ is required for .NET 6 support; 2.x is license-compatible with 1.x, and it doesn't seem to have caused any significant compatibility issues.
2. ImageSharp 2 moved PNG compression "levels" from numeric values to enumerated values.
3. There is a new ByteOrder type in ImageSharp 2.x that conflicts with Ico.Binary.ByteOrder. Instead of moving everything to the ImageSharp ByteOrder constants, I namespaced the few conflicting uses.
4. Many ImageSharp operations grew support for cancellation tokens. I chose to use the "None" CancellationToken instead of propagating cancellation across the surface of IcoLib.

An alternate means of addressing point three would be to resolve the conflicts in favor of ImageSharp's ByteOrder type. I believe that this would be much more invasive for minimal gain.